### PR TITLE
chore: Update `css-inline` to `0.10`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cffi==1.15.1
 charset-normalizer==2.1.1
 click==8.1.3
 colorama==0.4.5
-css-inline==0.8.4
+css-inline==0.10.1
 DateTime==4.7
 dnspython==2.2.1
 email-validator==1.3.0


### PR DESCRIPTION
Hi! This PR updates `css-inline` to its latest version (even though, it seems like the package is not used at the moment)